### PR TITLE
fix(ranking): 以账号身份标识替代邮箱硬编码来过滤 GM 账号上榜

### DIFF
--- a/Server/Envir/SEnvir.cs
+++ b/Server/Envir/SEnvir.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Drawing;
@@ -931,7 +931,7 @@ namespace Server.Envir
             {
                 if (info.Deleted || !info.Account.Activated 
                     || info.Account.Banned 
-                    || info.Account.EMailAddress == SuperAdmin) continue;
+                    || info.Account.Identify != AccountIdentity.Normal) continue;
 
                 info.RankingNode = Rankings.AddLast(info);
                 RankingSort(info, false);
@@ -975,8 +975,7 @@ namespace Server.Envir
         {
             if (character.Deleted
                 || !character.Account.Activated 
-                || character.Account.Banned 
-                || character.Account.EMailAddress == SuperAdmin)
+                || character.Account.Identify != AccountIdentity.Normal)
                 return;
 
             bool changed = false;
@@ -1040,8 +1039,8 @@ namespace Server.Envir
             {
                 if (cInfo.Deleted 
                     || !cInfo.Account.Activated 
-                    || cInfo.Account.Banned 
-                    || cInfo.Account.EMailAddress == SuperAdmin) 
+                    || cInfo.Account.Banned
+                    || cInfo.Account.Identify != AccountIdentity.Normal) 
                     continue;
 
                 switch (cInfo.Class)

--- a/Server/Envir/SEnvir.cs
+++ b/Server/Envir/SEnvir.cs
@@ -929,9 +929,7 @@ namespace Server.Envir
             TopRankings = new HashSet<CharacterInfo>();
             foreach (CharacterInfo info in CharacterInfoList.Binding)
             {
-                if (info.Deleted || !info.Account.Activated 
-                    || info.Account.Banned 
-                    || info.Account.Identify != AccountIdentity.Normal) continue;
+                if (!CanShowInRanking(info)) continue;
 
                 info.RankingNode = Rankings.AddLast(info);
                 RankingSort(info, false);
@@ -970,12 +968,21 @@ namespace Server.Envir
 
             Session.BackUpSpace = Config.玩家数据备份间隔;
         }
+        public static bool CanShowInRanking(CharacterInfo info)
+        {
+            if (info == null || info.Account == null) return false;
+
+            return !info.Deleted
+                && info.Account.Activated
+                && !info.Account.Banned
+                && info.Account.Identify == AccountIdentity.Normal
+                && info.Account.EMailAddress != SuperAdmin;
+        }
+
         //Only works on Increasing EXP, still need to do Rebirth or loss of exp ranking update.
         public static void RankingSort(CharacterInfo character, bool updateLead = true)
         {
-            if (character.Deleted
-                || !character.Account.Activated 
-                || character.Account.Identify != AccountIdentity.Normal)
+            if (!CanShowInRanking(character))
                 return;
 
             bool changed = false;
@@ -1037,10 +1044,7 @@ namespace Server.Envir
 
             foreach (CharacterInfo cInfo in Rankings)
             {
-                if (cInfo.Deleted 
-                    || !cInfo.Account.Activated 
-                    || cInfo.Account.Banned
-                    || cInfo.Account.Identify != AccountIdentity.Normal) 
+                if (!CanShowInRanking(cInfo))
                     continue;
 
                 switch (cInfo.Class)
@@ -4716,10 +4720,7 @@ namespace Server.Envir
             int rank = 0;
             foreach (CharacterInfo info in Rankings)
             {
-                if (info.Deleted 
-                    || !info.Account.Activated 
-                    || info.Account.Banned 
-                    || info.Account.EMailAddress == SuperAdmin) 
+                if (!CanShowInRanking(info))
                     continue;
 
                 switch (info.Class)


### PR DESCRIPTION
原逻辑通过 account.EMailAddress == SuperAdmin 判断管理员，
存在以下问题：
1. 依赖配置文件中的邮箱字符串，若邮箱变更则过滤失效
2. 语义不清晰

修改为 account.Identify != AccountIdentity.Normal，
直接使用账号的身份枚举进行判断，语义明确。
影响排行榜初始化、实时排序(RankingSort)和 TopRankings 更新(UpdateLead)三处。